### PR TITLE
Increase alternatives priority

### DIFF
--- a/debian/ruby2.0.postinst
+++ b/debian/ruby2.0.postinst
@@ -5,12 +5,12 @@ set -e
 if [ "$1" = "configure" ]
 then
         update-alternatives --install /usr/bin/gem gem \
-            /usr/bin/gem2.0 180 \
+            /usr/bin/gem2.0 181 \
 	    --slave /usr/share/man/man1/gem.1.gz gem.1.gz /usr/share/man/man1/gem2.0.1.gz \
             --slave /etc/bash_completion.d/gem bash_completion_gem /etc/bash_completion.d/gem2.0
         RUBYVER=2.0
         update-alternatives \
-		--install /usr/bin/ruby ruby /usr/bin/ruby${RUBYVER} 50 \
+		--install /usr/bin/ruby ruby /usr/bin/ruby${RUBYVER} 51 \
         --slave /usr/bin/erb erb /usr/bin/erb${RUBYVER} \
         --slave /usr/bin/testrb testrb /usr/bin/testrb${RUBYVER} \
         --slave /usr/bin/irb irb /usr/bin/irb${RUBYVER} \


### PR DESCRIPTION
Increase alternatives priority so 2.0 is preferred over 1.8. This brings it into line with the packaging for [1.9](https://github.com/brightbox/deb-ruby1.9.1/blob/master/debian/ruby1.9.1.postinst) and [2.1](https://github.com/brightbox/deb-ruby2.1/blob/master/debian/ruby2.1.postinst).
